### PR TITLE
[Feature] Add feed method for node. Optimize thread pool

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,17 @@
+format:
+	find ./ -iname "*.hpp" -o -iname "*.cpp" | xargs clang-format -i
+clean:
+	rm -rf build
+test:
+	echo "Running test"
+	cd build && ./graph_test
+
+.PHONY: build
+
+build:
+	echo "Building the project"
+	mkdir -p build
+	cd build && cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DRUN_BENCHMARK=ON .. && ninja -j8
+bench:
+	echo "Running the benchmark"
+	cd build && ./bmark

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -193,7 +193,6 @@ static void BM_FunctionCall_Expensive_Parallel(benchmark::State& state)
         auto f4 = pool.push(std::bind(fourthCostlyFunc, res));
         sixCostlyFunc(f1.get(), f2.get(), f3.get(), f4.get());
     }
-    pool.stop();
 }
 BENCHMARK(BM_FunctionCall_Expensive_Parallel);
 

--- a/benchmark.cpp
+++ b/benchmark.cpp
@@ -49,7 +49,7 @@ static void BM_FunctionCall(benchmark::State& state)
 }
 BENCHMARK(BM_FunctionCall);
 
-constexpr int loop_n = 10'000;
+constexpr int loop_n = 1'000'000;
 std::function<void(void)> firstCostlyFunc = []() -> void {
     for (int i = 0; i < loop_n; ++i)
         ;
@@ -68,8 +68,8 @@ std::function<int(int)> thirdCostlyFunc = [](int a) -> int {
     return a;
 };
 std::function<int(int)> fourthCostlyFunc = [](int a) -> int {
-    for (int i = 100; i >= 0; --i) {
-        for (int j = 1; j <= 100; ++j) {
+    for (int i = 1'000; i >= 0; --i) {
+        for (int j = 1; j <= 1'000; ++j) {
             a ^= (i % j);
             ++a;
         }

--- a/cptl.hpp
+++ b/cptl.hpp
@@ -46,12 +46,14 @@ public:
     thread_pool(int nThreads, int queueSize = _ctplThreadPoolLength_)
         : q(queueSize)
     {
-        this->init();
-        this->resize(nThreads);
+        this->threads.resize(nThreads);
+        for (int i = oldNThreads; i < nThreads; ++i) {
+            this->set_thread(i);
+        }
     }
 
     // the destructor waits for all the functions in the queue to be finished
-    ~thread_pool() { this->stop(true); }
+    ~thread_pool() { this->stop(); }
 
     // get the number of running threads in the pool
     int size() { return static_cast<int>(this->threads.size()); }
@@ -59,49 +61,6 @@ public:
     // number of idle threads
     int n_idle() { return this->nWaiting; }
     std::thread &get_thread(int i) { return *this->threads[i]; }
-
-    // change the number of threads in the pool
-    // should be called from one thread, otherwise be careful to not interleave,
-    // also with this->stop() nThreads must be >= 0
-    void resize(int nThreads)
-    {
-        if (!this->isStop && !this->isDone) {
-            int oldNThreads = static_cast<int>(this->threads.size());
-            if (oldNThreads <=
-                nThreads) {  // if the number of threads is increased
-                this->threads.resize(nThreads);
-                this->flags.resize(nThreads);
-
-                for (int i = oldNThreads; i < nThreads; ++i) {
-                    this->flags[i] = std::make_shared<std::atomic<bool>>(false);
-                    this->set_thread(i);
-                }
-            }
-            else {  // the number of threads is decreased
-                for (int i = oldNThreads - 1; i >= nThreads; --i) {
-                    *this->flags[i] = true;  // this thread will finish
-                    this->threads[i]->detach();
-                }
-                {
-                    // stop the detached threads that were waiting
-                    std::unique_lock<std::mutex> lock(this->mutex);
-                    this->cv.notify_all();
-                }
-                this->threads.resize(nThreads);  // safe to delete because the
-                                                 // threads are detached
-                this->flags.resize(
-                    nThreads);  // safe to delete because the threads have
-                                // copies of shared_ptr of the flags, not
-                                // originals
-            }
-        }
-    }
-
-    void reset()
-    {
-        this->init();
-        this->resize(this->threads.capacity());
-    }
 
     // empty the queue
     void clear_queue()
@@ -128,25 +87,13 @@ public:
 
     // wait for all computing threads to finish and stop all threads
     // may be called asyncronously to not pause the calling thread while waiting
-    // if isWait == true, all the functions in the queue are run, otherwise the
-    // queue is cleared without running the functions
-    void stop(bool isWait = false)
+    // All the functions in the queue are run
+    void stop()
     {
-        if (!isWait) {
-            if (this->isStop)
-                return;
-            this->isStop = true;
-            for (int i = 0, n = this->size(); i < n; ++i) {
-                *this->flags[i] = true;  // command the threads to stop
-            }
-            this->clear_queue();  // empty the queue
-        }
-        else {
-            if (this->isDone || this->isStop)
-                return;
-            this->isDone =
-                true;  // give the waiting threads a command to finish
-        }
+        if (this->isDone)
+            return;
+        this->isDone =
+            true;  // give the waiting threads a command to finish
         {
             std::unique_lock<std::mutex> lock(this->mutex);
             this->cv.notify_all();  // stop all waiting threads
@@ -161,26 +108,6 @@ public:
         // here
         this->clear_queue();
         this->threads.clear();
-        this->flags.clear();
-    }
-
-    template <typename F, typename... Rest>
-    auto push(F &&f, Rest &&... rest) -> std::future<decltype(f(0, rest...))>
-    {
-        auto pck =
-            std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
-                std::bind(std::forward<F>(f),
-                          std::placeholders::_1,
-                          std::forward<Rest>(rest)...));
-
-        auto _f =
-            new std::function<void(int id)>([pck](int id) { (*pck)(id); });
-        this->q.push(_f);
-
-        std::unique_lock<std::mutex> lock(this->mutex);
-        this->cv.notify_one();
-
-        return pck->get_future();
     }
 
     // run the user's function that excepts argument int - id of the running
@@ -211,10 +138,7 @@ private:
 
     void set_thread(int i)
     {
-        std::shared_ptr<std::atomic<bool>> flag(
-            this->flags[i]);  // a copy of the shared ptr to the flag
-        auto f = [this, i, flag /* a copy of the shared ptr to the flag */]() {
-            std::atomic<bool> &_flag = *flag;
+        auto f = [this, i]() {
             std::function<void(int id)> *_f;
             bool isPop = this->q.pop(_f);
             while (true) {
@@ -223,20 +147,15 @@ private:
                         _f);  // at return, delete the function even if an
                               // exception occurred
                     (*_f)(i);
-
-                    if (_flag)
-                        return;  // the thread is wanted to stop, return even if
-                                 // the queue is not empty yet
-                    else
-                        isPop = this->q.pop(_f);
+                    isPop = this->q.pop(_f);
                 }
 
                 // the queue is empty here, wait for the next command
                 std::unique_lock<std::mutex> lock(this->mutex);
                 ++this->nWaiting;
-                this->cv.wait(lock, [this, &_f, &isPop, &_flag]() {
+                this->cv.wait(lock, [this, &_f, &isPop]() {
                     isPop = this->q.pop(_f);
-                    return isPop || this->isDone || _flag;
+                    return isPop || this->isDone;
                 });
                 --this->nWaiting;
 
@@ -249,19 +168,10 @@ private:
             new std::thread(f));  // compiler may not support std::make_unique()
     }
 
-    void init()
-    {
-        this->nWaiting = 0;
-        this->isStop = false;
-        this->isDone = false;
-    }
-
     std::vector<std::unique_ptr<std::thread>> threads;
-    std::vector<std::shared_ptr<std::atomic<bool>>> flags;
     mutable boost::lockfree::queue<std::function<void(int id)> *> q;
-    std::atomic<bool> isDone;
-    std::atomic<bool> isStop;
-    std::atomic<int> nWaiting;  // how many threads are waiting
+    std::atomic<bool> isDone = false;
+    std::atomic<int> nWaiting = 0;  // how many threads are waiting
 
     std::mutex mutex;
     std::condition_variable cv;

--- a/cptl.hpp
+++ b/cptl.hpp
@@ -97,6 +97,12 @@ public:
         }
     }
 
+    void reset()
+    {
+        this->init();
+        this->resize(this->threads.capacity());
+    }
+
     // empty the queue
     void clear_queue()
     {

--- a/cptl_stl.hpp
+++ b/cptl_stl.hpp
@@ -124,6 +124,12 @@ public:
         }
     }
 
+    void reset()
+    {
+        this->init();
+        this->resize(this->threads.capacity());
+    }
+
     // empty the queue
     void clear_queue()
     {

--- a/cptl_stl.hpp
+++ b/cptl_stl.hpp
@@ -70,15 +70,17 @@ private:
 
 class thread_pool {
 public:
-    thread_pool() { this->init(); }
-    thread_pool(int nThreads)
+    thread_pool() noexcept = default;
+    thread_pool(int nThreads) noexcept
     {
-        this->init();
-        this->resize(nThreads);
+        this->threads.resize(nThreads);
+        for (int i = 0; i < nThreads; ++i) {
+            this->set_thread(i);
+        }
     }
 
     // the destructor waits for all the functions in the queue to be finished
-    ~thread_pool() { this->stop(true); }
+    ~thread_pool() { this->stop(); }
 
     // get the number of running threads in the pool
     int size() { return static_cast<int>(this->threads.size()); }
@@ -86,49 +88,6 @@ public:
     // number of idle threads
     int n_idle() { return this->nWaiting; }
     std::thread &get_thread(int i) { return *this->threads[i]; }
-
-    // change the number of threads in the pool
-    // should be called from one thread, otherwise be careful to not interleave,
-    // also with this->stop() nThreads must be >= 0
-    void resize(int nThreads)
-    {
-        if (!this->isStop && !this->isDone) {
-            int oldNThreads = static_cast<int>(this->threads.size());
-            if (oldNThreads <=
-                nThreads) {  // if the number of threads is increased
-                this->threads.resize(nThreads);
-                this->flags.resize(nThreads);
-
-                for (int i = oldNThreads; i < nThreads; ++i) {
-                    this->flags[i] = std::make_shared<std::atomic<bool>>(false);
-                    this->set_thread(i);
-                }
-            }
-            else {  // the number of threads is decreased
-                for (int i = oldNThreads - 1; i >= nThreads; --i) {
-                    *this->flags[i] = true;  // this thread will finish
-                    this->threads[i]->detach();
-                }
-                {
-                    // stop the detached threads that were waiting
-                    std::unique_lock<std::mutex> lock(this->mutex);
-                    this->cv.notify_all();
-                }
-                this->threads.resize(nThreads);  // safe to delete because the
-                                                 // threads are detached
-                this->flags.resize(
-                    nThreads);  // safe to delete because the threads have
-                                // copies of shared_ptr of the flags, not
-                                // originals
-            }
-        }
-    }
-
-    void reset()
-    {
-        this->init();
-        this->resize(this->threads.capacity());
-    }
 
     // empty the queue
     void clear_queue()
@@ -154,25 +113,13 @@ public:
 
     // wait for all computing threads to finish and stop all threads
     // may be called asynchronously to not pause the calling thread while
-    // waiting if isWait == true, all the functions in the queue are run,
-    // otherwise the queue is cleared without running the functions
-    void stop(bool isWait = false)
+    // waiting. All the functions in the queue are run.
+    void stop()
     {
-        if (!isWait) {
-            if (this->isStop)
-                return;
-            this->isStop = true;
-            for (int i = 0, n = this->size(); i < n; ++i) {
-                *this->flags[i] = true;  // command the threads to stop
-            }
-            this->clear_queue();  // empty the queue
-        }
-        else {
-            if (this->isDone || this->isStop)
-                return;
-            this->isDone =
-                true;  // give the waiting threads a command to finish
-        }
+        if (this->isDone)
+            return;
+        this->isDone =
+            true;  // give the waiting threads a command to finish
         {
             std::unique_lock<std::mutex> lock(this->mutex);
             this->cv.notify_all();  // stop all waiting threads
@@ -187,23 +134,6 @@ public:
         // here
         this->clear_queue();
         this->threads.clear();
-        this->flags.clear();
-    }
-
-    template <typename F, typename... Rest>
-    auto push(F &&f, Rest &&... rest) -> std::future<decltype(f(0, rest...))>
-    {
-        auto pck =
-            std::make_shared<std::packaged_task<decltype(f(0, rest...))(int)>>(
-                std::bind(std::forward<F>(f),
-                          std::placeholders::_1,
-                          std::forward<Rest>(rest)...));
-        auto _f =
-            new std::function<void(int id)>([pck](int id) { (*pck)(id); });
-        this->q.push(_f);
-        std::unique_lock<std::mutex> lock(this->mutex);
-        this->cv.notify_one();
-        return pck->get_future();
     }
 
     // run the user's function that excepts argument int - id of the running
@@ -231,10 +161,7 @@ private:
 
     void set_thread(int i)
     {
-        std::shared_ptr<std::atomic<bool>> flag(
-            this->flags[i]);  // a copy of the shared ptr to the flag
-        auto f = [this, i, flag /* a copy of the shared ptr to the flag */]() {
-            std::atomic<bool> &_flag = *flag;
+        auto f = [this, i]() {
             std::function<void(int id)> *_f;
             bool isPop = this->q.pop(_f);
             while (true) {
@@ -243,18 +170,14 @@ private:
                         _f);  // at return, delete the function even if an
                               // exception occurred
                     (*_f)(i);
-                    if (_flag)
-                        return;  // the thread is wanted to stop, return even if
-                                 // the queue is not empty yet
-                    else
-                        isPop = this->q.pop(_f);
+                    isPop = this->q.pop(_f);
                 }
                 // the queue is empty here, wait for the next command
                 std::unique_lock<std::mutex> lock(this->mutex);
                 ++this->nWaiting;
-                this->cv.wait(lock, [this, &_f, &isPop, &_flag]() {
+                this->cv.wait(lock, [this, &_f, &isPop]() {
                     isPop = this->q.pop(_f);
-                    return isPop || this->isDone || _flag;
+                    return isPop || this->isDone;
                 });
                 --this->nWaiting;
                 if (!isPop)
@@ -266,19 +189,10 @@ private:
             new std::thread(f));  // compiler may not support std::make_unique()
     }
 
-    void init()
-    {
-        this->nWaiting = 0;
-        this->isStop = false;
-        this->isDone = false;
-    }
-
     std::vector<std::unique_ptr<std::thread>> threads;
-    std::vector<std::shared_ptr<std::atomic<bool>>> flags;
     detail::Queue<std::function<void(int id)> *> q;
-    std::atomic<bool> isDone;
-    std::atomic<bool> isStop;
-    std::atomic<int> nWaiting;  // how many threads are waiting
+    std::atomic<bool> isDone = false;
+    std::atomic<int> nWaiting = 0;  // how many threads are waiting
 
     std::mutex mutex;
     std::condition_variable cv;

--- a/graphex.hpp
+++ b/graphex.hpp
@@ -303,6 +303,7 @@ public:
                 dfs(node.get());
         }
         _finishedCount = 0;
+        _pool.reset();
     }
 
     /// @brief run the graph execution from input nodes

--- a/test.cpp
+++ b/test.cpp
@@ -163,7 +163,6 @@ TEST_F(GraphExTest, ShouldBeAbleToHandleMovableObjectCorrectly)
 
         second->setParent(preprocess);
         second->setParent<0>(first);
-        second->markAsOutput();
 
         executor.execute();
         auto initial_input = first->collect();
@@ -187,8 +186,6 @@ TEST_F(GraphExTest, ShouldBeAbleToHandleMovableObjectCorrectly)
 
         second->setParent(preprocess);
         second->setParent<0>(first);
-        second->markAsOutput();
-        first->markAsOutput();
 
         executor.execute();
         auto final_output = second->collect();
@@ -215,7 +212,6 @@ TEST_F(GraphExTest, ShouldBeAbleToHandleNonCopyableStruct)
     decltype(auto) second = executor.makeNode(secondFunc);
 
     second->setParent<0>(first);
-    second->markAsOutput();
 
     executor.execute();
     std::cout << "Done running\n";
@@ -283,7 +279,6 @@ TEST_F(GraphExTest, ShouldBeAbleToAddStructMethod)
     decltype(auto) second = executor.makeNode(secondFunc);
 
     second->setParent<0>(first);
-    second->markAsOutput();
 
     executor.execute();
 

--- a/test.cpp
+++ b/test.cpp
@@ -505,6 +505,37 @@ TEST_F(GraphExTest, ResetAndExecuteRepeatedly)
     }
 }
 
+
+TEST_F(GraphExTest, ShouldBeAbleToInjectParameterManually)
+{
+    GraphEx executor;
+    std::function<int(int)> secondFunc = [](int a) -> int { return a; };
+    decltype(auto) second = executor.makeNode(secondFunc);
+    std::function<int(int)> thirdFunc = [](int a) -> int { return a + 2; };
+    decltype(auto) third = executor.makeNode(thirdFunc);
+    std::function<int(int)> fourthFunc = [](int a) -> int { return a * 2; };
+    decltype(auto) fourth = executor.makeNode(fourthFunc);
+    std::function<int(int, int)> fifthFunc = [](int a, int b) -> int {
+        return a % b;
+    };
+    decltype(auto) fifth = executor.makeNode(fifthFunc);
+
+    third->setParent<0>(second);
+    fourth->setParent<0>(second);
+    fifth->setParent<0>(third);
+    fifth->setParent<1>(fourth);
+
+    second->feed<0>(10);
+    executor.execute();
+    EXPECT_EQ(fifth->collect(), 12);
+
+    executor.reset();
+    second->feed<0>(20);
+    executor.execute();
+    EXPECT_EQ(fifth->collect(), 22);
+}
+
+
 auto main(int argc, char** argv) -> int
 {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
- Add method for node to manually inject parameter
- Modify the graph flow logic: 
    - Previously, if all parent nodes has finished executed, then the child will be enqueued for execution
    + Now, the child will always be enqueued after parent nodes are enqueued, then wait for parent nodes to finish execution before it actuall starts executing
- Add makefile to enable chaining of commands, eg `make build test bench`